### PR TITLE
.github/workflows: use ubuntu 20.04 and python 3.6 everywhere

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,14 +5,14 @@ on: workflow_dispatch
 jobs:
   release:
     name: Bump Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup Python 3.8
+    - name: Setup Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install -U pip wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Coding style and linting checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -24,7 +24,7 @@ jobs:
 
   test:
     name: Test with docker image ${{ matrix.docker-image }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         docker-image: ['ubuntu:xenial', 'ubuntu:bionic', 'ubuntu:focal', 'debian:bullseye']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,14 @@ on: workflow_dispatch
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup Python 3.8
+    - name: Setup Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.6
     - name: Install dependencies
       run: |
         python -m pip install -U pip wheel twine


### PR DESCRIPTION
Now the python 3.6 package is not available on ubuntu-latest. ubuntu-latest has been set to ubuntu-22.04 (Ubuntu 22.04).

Learn more: https://github.com/actions/runner-images/issues/6399