### PR TITLE
bldr/docker_utils.py: increase timeout of docker API calls

### DIFF
--- a/bldr/bldr.py
+++ b/bldr/bldr.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Dict, IO, List, Union, Optional
 from tempfile import TemporaryDirectory
 
-from .docker_utils import create_docker_client, DockerImageBuilder, DockerImage, DockerContainer
+from .docker_utils import create_docker_client, DockerImageBuilder, DockerImage, DockerContainer, DEFAULT_DOCKER_TIMEOUT
 from .utils import BLDRError, BLDRSetupFailed, escape_docker_image_tag, get_resource
 
 
@@ -30,6 +30,7 @@ class BLDR:
         container_env: Optional[Dict] = None,
         hooks_dir: Optional[Path] = None,
         disable_tmpfs: bool = False,
+        docker_timeout: int = DEFAULT_DOCKER_TIMEOUT,
     ) -> None:
 
         if ("\n" in docker_from or " " in docker_from):
@@ -56,7 +57,7 @@ class BLDR:
         self._nonpriv_user_name = pwd.getpwuid(self._nonpriv_user_uid).pw_name
 
         self._tmp_on_tmpfs = not disable_tmpfs
-        self._docker_client = create_docker_client()
+        self._docker_client = create_docker_client(docker_timeout)
 
     @property
     def local_repo_dir(self) -> Path:

--- a/bldr/cli.py
+++ b/bldr/cli.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from typing import List, Tuple
 
 from .bldr import BLDR
+from .docker_utils import DEFAULT_DOCKER_TIMEOUT
 from .version import get_version
 from .utils import BLDRError, escape_docker_image_tag, get_config_file_paths
 from .config import ArgumentParser, JSONConfigLoader, ConfigLoader, SubParsers
@@ -114,6 +115,12 @@ class CLI:
             "--disable-tmpfs",
             help="Disable using tmpfs.",
             action="store_true",
+        )
+        parser.add_argument(
+            "--docker-timeout",
+            help="Timeout for docker API calls, in seconds. (default: %(default)s)",
+            type=int,
+            action='store', default=os.environ.get('BLDR_DOCKER_TIMEOUT', DEFAULT_DOCKER_TIMEOUT)
         )
 
     def _create_config_loader(self) -> ConfigLoader:
@@ -240,6 +247,7 @@ class CLI:
             container_env=dict(self.args.container_env),
             hooks_dir=self.args.hooks_dir,
             disable_tmpfs=self.args.disable_tmpfs,
+            docker_timeout=self.args.docker_timeout,
         )
         return bldr
 

--- a/bldr/docker_utils.py
+++ b/bldr/docker_utils.py
@@ -15,9 +15,12 @@ from requests import RequestException
 from .utils import BLDRSetupFailed
 
 
-def create_docker_client() -> DockerClient:
+DEFAULT_DOCKER_TIMEOUT = 600
+
+
+def create_docker_client(docker_timeout: int = DEFAULT_DOCKER_TIMEOUT) -> DockerClient:
     try:
-        return docker.from_env(version='auto', timeout=600)
+        return docker.from_env(version='auto', timeout=docker_timeout)
     except DockerException as e:
         raise BLDRSetupFailed(
             'Cannot create Docker client. Is Docker daemon running?\nAdditional info: {}'.format(e)

--- a/bldr/docker_utils.py
+++ b/bldr/docker_utils.py
@@ -17,7 +17,7 @@ from .utils import BLDRSetupFailed
 
 def _create_docker_client() -> DockerClient:
     try:
-        return docker.from_env(version='auto')
+        return docker.from_env(version='auto', timeout=600)
     except DockerException as e:
         raise BLDRSetupFailed(
             'Cannot create Docker client. Is Docker daemon running?\nAdditional info: {}'.format(e)


### PR DESCRIPTION
In the communication of docker socket if there is no data transfer for 60 seconds then the docker API throws a timeout exception. It cause that the output stream of exec is stopped before the command running finished. The exec inspect cannot determine the exit code of the running command and tries to compare with None, which cause the following exception:

TypeError: '>' not supported between instances of 'NoneType' and 'int'