### PR TITLE
init-docker-image: remove ubuntu user if it exists

### DIFF
--- a/bldr/bldr.py
+++ b/bldr/bldr.py
@@ -214,7 +214,7 @@ class BLDR:
 
                 assert container.exec(command=['false']) == 1, "return code should be returned"
 
-                cmd = 'useradd -u 1000 user && su user -c whoami'   # checking for possible SELinux issues
+                cmd = 'useradd -u 1001 user && su user -c whoami'   # checking for possible SELinux issues
                 assert container.exec_run(command=['bash', '-c', cmd]) == 'user\n', "'su user' should succeed"
 
                 cmd = 'echo "deb http://archive.ubuntu.com/ubuntu {} main universe" > /etc/apt/sources.list'.format(ubuntu_release)

--- a/bldr/bldr.py
+++ b/bldr/bldr.py
@@ -205,7 +205,7 @@ class BLDR:
     @classmethod
     def selftest(cls) -> None:
         client = create_docker_client()
-        for ubuntu_release in ['focal', 'jammy']:
+        for ubuntu_release in ['focal', 'jammy', 'noble']:
             image = DockerImage(client=client, image='ubuntu:{}'.format(ubuntu_release))
             assert image is not None, "DockerImage should be initialized without Exception"
 

--- a/bldr/data/files/usr/local/bin/init-docker-image
+++ b/bldr/data/files/usr/local/bin/init-docker-image
@@ -3,6 +3,11 @@
 set -e
 echo "Preparing BLDR deb builder docker image"
 
+if getent passwd ubuntu; then
+    echo "Deleting ubuntu user"
+    userdel -r ubuntu
+fi
+
 echo "Adding non-privileged user ${NONPRIV_USER_NAME} with uid ${NONPRIV_USER_UID}"
 useradd -u ${NONPRIV_USER_UID} ${NONPRIV_USER_NAME} -m
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import shutil
 from pathlib import Path
 
-DEFAULT_DOCKER_IMAGES = ["ubuntu:focal", "ubuntu:jammy"]
+DEFAULT_DOCKER_IMAGES = ["ubuntu:focal", "ubuntu:jammy", "ubuntu:noble"]
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Noble has a predefined ubuntu user with an 1000 uid. This prevents the creation of another user with 1000 uid so we need to delete it if it exists.

Noble is also added to the test distributions.