### PR TITLE
bldr.py, cli.py: implement build profiles

### DIFF
--- a/bldr/bldr.py
+++ b/bldr/bldr.py
@@ -24,6 +24,7 @@ class BLDR:
         source_dir: Path,
         docker_from: str,
         deb_build_options: Optional[str] = None,
+        build_profiles: Optional[List[str]] = None,
         debug_shell: bool = False,
         snapshot: bool = False,
         nocache: bool = False,
@@ -43,6 +44,7 @@ class BLDR:
 
         self._debug_shell = debug_shell
         self._deb_build_options = deb_build_options
+        self._build_profiles = [] if build_profiles is None else build_profiles
         self._snapshot = snapshot
         self._nocache = nocache
 
@@ -148,6 +150,8 @@ class BLDR:
             env_vars['no_proxy'] = os.environ.get('no_proxy')
         if self._deb_build_options is not None:
             env_vars['DEB_BUILD_OPTIONS'] = self._deb_build_options
+        if self._build_profiles:
+            env_vars['DEB_BUILD_PROFILES'] = ' '.join(self._build_profiles)
         env_vars['BLDR_SNAPSHOT'] = '1' if self._snapshot else ''
         env_vars['TERM'] = os.environ.get('TERM', 'xterm-256color')
         env_vars['USER'] = self._nonpriv_user_name

--- a/bldr/cli.py
+++ b/bldr/cli.py
@@ -84,6 +84,11 @@ class CLI:
             action='store', default=os.environ.get('DEB_BUILD_OPTIONS', None)
         )
         parser.add_argument(
+            '--build-profiles',
+            help="Profiles for the build as a comma-separated list (default: no specific profile).",
+            action='store'
+        )
+        parser.add_argument(
             '--local-repo-dir',
             help="The directory for the local apt repository. The value will be: "
                  "1. This argument, if given. "
@@ -241,6 +246,7 @@ class CLI:
             source_dir=Path().cwd().parent,
             docker_from=self.args.docker_from,
             deb_build_options=self.args.deb_build_options,
+            build_profiles=[] if self.args.build_profiles is None else self.args.build_profiles.split(','),
             debug_shell=self.args.shell,
             snapshot=self.args.snapshot,
             nocache=self.args.nocache,


### PR DESCRIPTION
If --build-profiles is specified, pass the DEB_BUILD_PROFILES environment variable into the build container.