### PR TITLE
bldr/docker_utils.py: froce remove if kill fails at exit

### DIFF
--- a/bldr/docker_utils.py
+++ b/bldr/docker_utils.py
@@ -147,9 +147,11 @@ class DockerContainer:
         return self._client.api.inspect_container(self._container.id)['State'].get('ExitCode', 0)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        force_remove = False
         try:
             self._container.kill()
-        except APIError:
-            pass
+        except APIError as error:
+            force_remove = True
+            self._logger.error(f"Failed to kill container; {error=}")
         finally:
-            self._container.remove()
+            self._container.remove(force=force_remove)


### PR DESCRIPTION
The cleanup during the exit from `DockerContainer` context could fail because if docker couldn't kill the container it won't be able to remove it either. Therefore we kill the container with force option if the kill failed.