### PR TITLE
.github/workflows: switch images to Ubuntu noble

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   release:
     name: Bump Version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Coding style and linting checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - run: |
@@ -22,7 +22,7 @@ jobs:
 
   test:
     name: Test with docker image ${{ matrix.docker-image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         docker-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - run: |


### PR DESCRIPTION
Ubuntu focal (20.4) images are not supported for Github Actions since 2025-04-15.

References: https://github.com/actions/runner-images/issues/11101